### PR TITLE
feat: 구매 페이지 상품 필터링 및 구매 신청 페이지 이동 기능

### DIFF
--- a/controller/Cproduct.js
+++ b/controller/Cproduct.js
@@ -1,9 +1,15 @@
 const db = require('../models');
 
-// 화면 렌더링 및 전체 판매글 조회 (판매자 측)
+// 화면 렌더링
+exports.renderProducts = (req, res) => {
+  res.status(200).render('purchase', { currentPage: 'product' });
+};
+
+// 전체 판매글 조회 (판매자 측)
 exports.getAllProducts = (req, res) => {
   db.Product.findAll({
     attributes: [
+      'category_id',
       'product_key',
       'name',
       'deadline',
@@ -12,20 +18,19 @@ exports.getAllProducts = (req, res) => {
       'image',
     ],
   })
-    .then((products) => {
-      console.log('전체 상품 데이터:', products);
-      res.status(200).render('purchase', { products, currentPage: 'product' });
+    .then((result) => {
+      // console.log('컨트롤러 전체 상품 데이터:', products);
+      res.status(200).json(result);
     })
     .catch((err) => {
-      res.status(500).render('purchase', {
+      res.status(500).json({
         isSuccess: false,
-        currentPage: 'product',
-        products: [],
         message: '서버 에러가 발생했습니다.',
       });
     });
 };
 
+// 특정 카테고리 상품 데이터 조회
 exports.getItemsByCategory = (req, res) => {
   const categoryId = req.params.id;
   db.Product.findAll({
@@ -42,7 +47,7 @@ exports.getItemsByCategory = (req, res) => {
     ],
   })
     .then((result) => {
-      console.log('result', result);
+      console.log('특정 카테고리 상품 데이터', result);
       res.status(200).json(result);
     })
     .catch((err) => {

--- a/routes/product.js
+++ b/routes/product.js
@@ -3,17 +3,25 @@ const router = express.Router();
 const productController = require('../controller/Cproduct');
 const authController = require('../controller/Cauth');
 
-// 화면 렌더링 + 전체 상품 데이터 API
+// 화면 렌더링
+// GET/ products
+router.get('/', productController.renderProducts);
+
+/* 필터링 버튼 데이터 불러오기 API */
+
+// 1. 전체 상품 데이터 불러오기
+// GET/ products/all
 router.get(
-  '/',
+  '/all',
   // authController.isSessionValid,
   productController.getAllProducts
 );
 
-// 특정 카테고리 상품 데이터 API
+// 2. 특정 카테고리 상품 데이터 불러오기
+// GET/ products/:id
 router.get(
   '/:id',
-  authController.isSessionValid,
+  // authController.isSessionValid,
   productController.getItemsByCategory
 );
 

--- a/views/purchase.ejs
+++ b/views/purchase.ejs
@@ -159,18 +159,28 @@
     const productGrid = document.querySelector('.productGrid');
     const filterButtons = document.querySelectorAll('.filterBtn');
 
-    // 상품 목록 업데이트 함수 (SPA)
+    // 상품 목록 업데이트 함수 (SPA 방식)
     const updateProductGrid = (products) => {
       productGrid.innerHTML = '';
       if (Array.isArray(products) && products.length > 0) {
         products.forEach((product) => {
+          // 상품 카드
           const productCard = `
             <div class="productCard">
-              <img src="/public/img/${product.image}" alt="${product.name}" />
-              <div class="productDetails">
-                <div>${product.name}</div>
-                <div>${product.price}원</div>
-              </div>
+              <a
+                href="/buyform/${product.product_key}"
+                target="buyform"
+                onclick="window.open(this.href, 'buyform', 'width=800,height=600'); return false;"
+              >
+                <img src="/public/img/${product.image}" alt="${product.name}" />
+                <div class="productDetails">
+                  <div>${product.name}</div>
+                  <div>${product.price}원</div>
+                </div>
+              </a>
+
+              <!-- 임시 찜 버튼(wishlist) -->
+              <button class="addWishBtn">임시 찜 버튼</button>
             </div>`;
           productGrid.innerHTML += productCard;
         });

--- a/views/purchase.ejs
+++ b/views/purchase.ejs
@@ -120,7 +120,7 @@
   <br />
   <main class="max-container">
     <!-- 카테고리 필터 -->
-    <!-- 식품/ 전자기기/의류 -->
+    <!-- 1 식품/ 2 전자기기/ 3 도서-->
     <ul class="categoryFilter">
       <li>
         <button class="filterBtn active" data-category="all">
@@ -128,57 +128,29 @@
           <span>전체</span>
         </button>
       </li>
+      <!-- (todo) 필터 버튼 이미지 교체하기 -->
       <li>
-        <button class="filterBtn" data-category="1">
+        <button class="filterBtn foods" data-category="1">
+          <img src="/public/img/filter-books.png" alt="식품" />
+          <span>식품</span>
+        </button>
+      </li>
+      <li>
+        <button class="filterBtn" data-category="2">
           <img src="/public/img/filter-electronics.png" alt="전자기기" />
           <span>전자기기</span>
         </button>
       </li>
       <li>
-        <button class="filterBtn clothes" data-category="2">
-          <img src="/public/img/filter-clothes.png" alt="의류" />
-          <span>의류</span>
-        </button>
-      </li>
-      <!-- (todo) 필터 버튼 이미지 교체하기 -->
-      <li>
-        <button class="filterBtn foods" data-category="3">
-          <img src="/public/img/filter-books.png" alt="식품" />
-          <span>식품</span>
+        <button class="filterBtn clothes" data-category="3">
+          <img src="/public/img/filter-clothes.png" alt="도서" />
+          <span>도서</span>
         </button>
       </li>
     </ul>
 
     <!-- 상품 목록 -->
-    <div class="productGrid max-container">
-      <% if (products && products.length > 0) { %> <%
-      products.forEach((product)=> { %>
-
-      <!--상품 카드-->
-
-      <div class="productCard" data-category-id="<%= product.product_key %>">
-        <a
-          href="/buyform/<%= product.product_key %>"
-          target="buyform"
-          onclick="window.open(this.href, 'buyform', 'width=800,height=600'); return false;"
-        >
-          <img
-            src="/public/img/<%= product.image %>"
-            alt="<%= product.name %>"
-          />
-          <div class="productDetails">
-            <div class="productName"><%= product.name %></div>
-            <div class="productPrice"><%= product.price %> 원</div>
-          </div>
-        </a>
-        <!-- 임시 찜 버튼(wishlist) -->
-        <button class="addWishBtn">임시 찜 버튼</button>
-      </div>
-
-      <% }) %> <% } else { %>
-      <p>등록된 상품이 없습니다.</p>
-      <% } %>
-    </div>
+    <div class="productGrid max-container"></div>
   </main>
 </body>
 
@@ -187,38 +159,69 @@
     const productGrid = document.querySelector('.productGrid');
     const filterButtons = document.querySelectorAll('.filterBtn');
 
-    // (todo) 상품 목록 업데이트 함수
+    // 상품 목록 업데이트 함수 (SPA)
     const updateProductGrid = (products) => {
-      productGrid.innerHTML = ''; // 기존 목록 초기화
+      productGrid.innerHTML = '';
+      if (Array.isArray(products) && products.length > 0) {
+        products.forEach((product) => {
+          const productCard = `
+            <div class="productCard">
+              <img src="/public/img/${product.image}" alt="${product.name}" />
+              <div class="productDetails">
+                <div>${product.name}</div>
+                <div>${product.price}원</div>
+              </div>
+            </div>`;
+          productGrid.innerHTML += productCard;
+        });
+      } else {
+        productGrid.innerHTML = '<p>등록된 상품이 없습니다.</p>';
+      }
     };
 
-    // (todo) 카테고리 필터링 API 호출
-    // const getItemsByCategory = async (categoryId) => {
-    //   try {
-    //     const res = await axios.get(`/products/${categoryId}`);
-    //     console.log(`카테고리 ${categoryId} 데이터:`, res.data);
-    //     updateProductGrid(res.data); // 받아온 데이터로 업데이트
-    //   } catch (err) {
-    //     console.error(`카테고리 ${categoryId} 데이터 호출 오류:`, err);
-    //   }
-    // };
+    // 전체 상품 가져오기
+    const getAllProducts = async () => {
+      try {
+        const res = await axios.get('/products/all');
+        updateProductGrid(res.data);
+      } catch (err) {
+        console.error('전체 상품 데이터 오류:', err);
+      }
+    };
 
-    // 필터 버튼 클릭 이벤트
+    // 카테고리별 상품 가져오기
+    const getItemsByCategory = async (categoryId) => {
+      try {
+        const res = await axios.get(`/products/${categoryId}`);
+        console.log('뷰 카테고리 상품 데이터:', res.data);
+        updateProductGrid(res.data);
+      } catch (err) {
+        console.error('카테고리 상품 데이터 오류:', err);
+      }
+    };
+
+    // 필터 버튼 이벤트 리스너
     filterButtons.forEach((button) => {
       button.addEventListener('click', () => {
-        // 모든 버튼의 활성화 상태 초기화
+        // 모든 버튼 활성화 상태 초기화
         filterButtons.forEach((btn) => btn.classList.remove('active'));
         button.classList.add('active');
 
         const categoryId = button.dataset.category;
 
         if (categoryId === 'all') {
-          location.reload(); // 페이지 새로고침
+          //URL 변경 API : history.pushState(state, title, url)
+          history.pushState(null, '', '/products/all');
+          getAllProducts();
         } else {
-          getItemsByCategory(categoryId); // API 호출로 데이터 업데이트
+          history.pushState(null, '', `/products/${categoryId}`);
+          getItemsByCategory(categoryId);
         }
       });
     });
+
+    // 초기화: 전체 상품 가져오기
+    getAllProducts();
   });
 
   // (todo) 찜 목록


### PR DESCRIPTION
## 요약
[상품 구매 페이지]
- 카테고리(전체, 식품, 전자기기, 도서)에 따른 상품 필터링 기능
- 상품 카드 클릭 시 해당하는 구매 신청 페이지 새 창으로 이동

## 주요 구현 사항
- [x] 프론트엔드 개선 `purchase.ejs` : 상품 그리드 동적 업데이트 
- [x] 구매 페이지 화면 렌더링, 데이터 조회 API 분리
- [x] 필터링 버튼 클릭 시 페이지 새로 고침 없이 해당 category_id의 데이터 조회 (SPA 방식으로 사용자 경험 향상)

## 이슈
- 페이지 주소로 접속 시 화면 렌더링이 아닌 Json 형태 파일로 확인됨
- 페이지 뒤로 가기 클릭 시 바뀐 주소의 데이터를  불러오지 못하고, 페이지 변화 없음
- 상품 이미지 불러오지 못함

## BE 리뷰 요청 사항

@CWJ1222 
구매 신청 페이지 연결은 이상 없고 추가 변경사항은 없습니다. 임시 찜 버튼도 그대로 유지됩니다.

 @gogigogigogi 
미구현 사항 관련, 아래 API path 변경 관련하여 검토 요청드립니다. 불완전한 부분이 있어 목요일 대면 피드백 요청드립니다.

`product.js` 라우팅: 화면 렌더링과 데이터 불러오는 API를 분리하였는데 '이슈'에서 언급한 문제가 있습니다.
- `/products` : 구매 페이지 진입 (기존과 동일)
- `/products/all` : 필터링 버튼 중 '전체' 클릭 시 (New)
- `/products/:id`: 해당 카테고리 상품 조회 (기존과 동일)


## 관련 스크린샷 
> 전체 조회
<img width="1274" alt="image" src="https://github.com/user-attachments/assets/058e5b95-0868-4186-a0a6-1c138b9aeaa3" />

> 전자기기 조회
<img width="1282" alt="image" src="https://github.com/user-attachments/assets/60cfafbd-ae99-485f-af7c-c0b44a00eeee" />

> 상품 카드 클릭 시

(예: http://localhost:8080/buyform/22)
<img width="589" alt="image" src="https://github.com/user-attachments/assets/0a29dbb2-c350-473a-98e8-39011e857dbf" />



